### PR TITLE
[2주차] : BOJ 7579 / 앱 / 골드 3

### DIFF
--- a/KSH/BOJ_7579.cpp
+++ b/KSH/BOJ_7579.cpp
@@ -1,0 +1,42 @@
+//
+// Created by Kim So Hee on 2022/08/21.
+//
+
+#include <bits/stdc++.h>
+
+#define MAX 10'000'000
+
+using namespace std;
+
+int N, M;
+int active[101], cost[101];
+int dp[10001]; // dp[cost] = max memory
+
+int main() {
+    ios::sync_with_stdio(false);
+    cin.tie(nullptr);
+    cout.tie(nullptr);
+
+    cin >> N >> M;
+    for (int i = 0; i < N; ++i) cin >> active[i];
+    for (int i = 0; i < N; ++i) cin >> cost[i];
+
+    /**
+     * 메모리 M 이상 확보, cost 최소 비용
+     * 냅색
+     *   dp[i] = max dp[i - cost[j]] + active[j]
+     */
+
+    for (int j = 0; j < N; ++j) {
+        for (int i = 10000; i >= cost[j]; --i) {
+            dp[i] = max(dp[i], dp[i - cost[j]] + active[j]);
+        }
+    }
+
+    for (int i = 0; i < 10001; ++i) {
+        if (dp[i] >= M) {
+            cout << i;
+            return 0;
+        }
+    }
+}


### PR DESCRIPTION
## 문제 설명
[앱](https://www.acmicpc.net/problem/7579)

앱들을 비활성화하여 메모리 M 이상을 확보하고, 그 때의 최소 비용을 구하자. 
 - 입력 : 앱 i가 차지하는 메모리, 비활성화 하는 비용


## 구현 방법
대표적인 배낭 (Knapsack, DP) 문제이다. 

특이한 점은 메모리 M의 범위가 10,000,000이라서 **비용(최대 10,000)을 기준**으로 잡아야 한다.
 - dp[비용] = 비활성화 가능한 최대 메모리
 - 앱 최대 100개, 앱 하나 당 비용 최대 100

```c++
    /**
     * 메모리 M 이상 확보, cost 최소 비용
     * 냅색, 1차원 dp
     *   dp[i] = max dp[i - cost[j]] + active[j]
     */

    for (int j = 0; j < N; ++j) {
        for (int i = 10000; i >= cost[j]; --i) {
            dp[i] = max(dp[i], dp[i - cost[j]] + active[j]);
        }
    }
```

## 참고 사항
 - 시간 복잡도 : `O(10000 * N)`