### PR TITLE
[3주차] : BOJ 1005 / ACM Craft / 골드 3

### DIFF
--- a/KSH/BOJ_1005.cpp
+++ b/KSH/BOJ_1005.cpp
@@ -1,0 +1,53 @@
+//
+// Created by Kim So Hee on 2022/08/25.
+//
+
+#include <bits/stdc++.h>
+
+using namespace std;
+
+int main() {
+    ios::sync_with_stdio(false);
+    cin.tie(nullptr);
+    cout.tie(nullptr);
+
+    int t;
+    cin >> t;
+    while (t--) {
+        int n, k;
+        cin >> n >> k;
+        vector<int> times(n + 1);
+        vector<int> indegree(n + 1), visited(n + 1);
+        vector<vector<int>> graph(n + 1);
+        for (int i = 1; i <= n; ++i) {
+            cin >> times[i];
+        }
+        for (int i = 0; i < k; ++i) {
+            int x, y;
+            cin >> x >> y;
+            graph[x].push_back(y);
+            indegree[y]++;
+        }
+        int w;
+        cin >> w;
+
+        queue<int> q;
+        for (int i = 1; i < indegree.size(); ++i) {
+            if (indegree[i] == 0) {
+                q.push(i);
+                visited[i] = times[i];
+            }
+        }
+
+        while (!q.empty()) {
+            int here = q.front();
+            q.pop();
+            for (const auto &child: graph[here]) {
+                indegree[child]--;
+                visited[child] = max(visited[child], visited[here] + times[child]);
+                if (indegree[child] == 0) q.push(child);
+            }
+        }
+        cout << visited[w] << '\n';
+    }
+}


### PR DESCRIPTION
## 문제 설명
[ACM Craft](https://www.acmicpc.net/problem/1005)

<img width="563" alt="image" src="https://user-images.githubusercontent.com/74011724/186701313-30eb3172-42e1-4a35-a60d-8d44735e7fdd.png">

특정건물 w을 가장 빨리 지을 때까지 걸리는 최소시간을 출력한다. 

## 구현 방법

1. queue 기반 **위상 정렬**

   1. 작업의 순서가 정해져 있으므로, `진입 차수(indegree)가 0`인 노드를 queue에 삽입한다. 
   2. 방문 에정인 자식 노드의 indegree를 1 감소시킨다. 

```c++
        while (!q.empty()) {
            int here = q.front();
            q.pop();
            for (const auto &child: graph[here]) {
                indegree[child]--; // 자식 차수 감소
                visited[child] = max(visited[child], visited[here] + times[child]);
                if (indegree[child] == 0) q.push(child);
            }
        }
```

2. 건물 w를 짓기 위한 **최소 시간**

   1. 위상 정렬은 작업의 순서만 알아 내므로, 걸리는 시간은 따로 구해야 한다. 
   2. dp[방문 에정 노드] = dp[현재 노드] + time[방문 예정 노드]
      1.  `visited[child] = max(visited[child], visited[here] + times[child]);`
      2. 건물 w를 짓기 위해서 w 이전 순서인 건물이 모두 지어져야 하므로, dp[이전 건물]의 max 값을 사용한다. 

## 참고 사항
 - 시간 복잡도 : `O(V + E)`
 - [위상 정렬](https://m.blog.naver.com/ndb796/221236874984)