### PR TITLE
[3주차] : BOJ 1182 / 부분수열의 합 / 실버 2

### DIFF
--- a/KHE/BOJ_1182.cpp
+++ b/KHE/BOJ_1182.cpp
@@ -1,0 +1,29 @@
+#include <iostream>
+using namespace std;
+
+int n, s;
+int cnt = 0;
+int arr[21] = { 0, };
+
+void find(int k, int sum) {
+
+	if (k == n) {
+		if (sum == s) cnt++;
+		return;
+	}
+
+	find(k + 1, sum);
+	find(k + 1, sum + arr[k]);
+}
+
+int main() {
+	cin >> n >> s;
+	for (int i = 0; i < n; i++) {
+		cin >> arr[i];
+	}
+
+	find(0, 0);
+	
+	if (s == 0) cnt--;
+	cout << cnt << '\n';
+}


### PR DESCRIPTION
## 문제 설명
[부분수열의 합](https://www.acmicpc.net/problem/1182)

N개의 정수로 이루어진 수열이 있을 때, 그 수열의 원소를 다 더한 값이 S가 되는 부분수열의 수를 구한다.

`예시`
[-7 -3 -2 5 8] 의 수열이 주어졌을 때, 합이 0 되는 부분수열은 [-3 -2 5] 한 개이다.

## 구현 방법

각 수열의 원소는 부분집합에 포함 되거나, 포함 되지 않거나의 두 가지로 나뉜다.
그러므로 부분집합의 합을 구할 때도 그 합에 원소를 더하거나, 더하지 않거나의 경우로 나누어 구할 수 있고, 이는 재귀호출의 형태로 구현이 가능하다.
![image](https://user-images.githubusercontent.com/76279010/187054134-8479ad73-f28b-40c8-8987-810b49a8ecea.png)

최종적으로 모든 원소를 더 할지 말지를 결정했을 때, 그 값이 문제에서 주어진 값과 같으면 카운트 값을 +1 한다.

```c
void find(int k, int sum) {
	if (k == n) {
		if (sum == s) cnt++;
		return;
	}

	find(k + 1, sum); 
	find(k + 1, sum + arr[k]);
}
```

합이 0일 때를 구해야하는 경우, 공집합도 카운트에 포함 되므로 이를 빼주기 위한 코드 또한 작성한다.
```c
if (s == 0) cnt--;
```

## 참고 사항
- 시간 복잡도 : `O(2^N)`