### PR TITLE
[3주차] : BOJ 1002 / 터렛 / 실버 3

### DIFF
--- a/KES/BOJ_1002.cpp
+++ b/KES/BOJ_1002.cpp
@@ -1,0 +1,23 @@
+#include<iostream>
+#include<algorithm>
+using namespace std;
+int main() {
+	int t;
+	cin >> t;
+	while (t--) {
+		int x1, y1, x2, y2, r1, r2, x, y, r, R;
+		cin >> x1 >> y1 >> r1 >> x2 >> y2 >> r2;
+		x = (x1 - x2) * (x1 - x2);
+		y = (y1 - y2) * (y1 - y2);
+		r = (r1 + r2) * (r1 + r2);
+		R = (r1 - r2) * (r1 - r2);
+		
+		if (x == 0 && y == 0) {
+			if (R == 0) cout << "-1" << '\n';
+			else  cout << "0" << '\n';
+		}
+		else if (x + y == r || R == x + y)cout << "1" << '\n';
+		else if (x + y < r && x + y > R) cout << "2" << '\n';
+		else cout << "0" << '\n';
+	}
+}


### PR DESCRIPTION
## 문제 설명
[터렛](https://www.acmicpc.net/problem/1002)

조규현 (x1, y1)과 류재명의 거리 : r1
백승환 (x2, y2)과 류재명의 거리 : r2
가 주어졌을 때, 류재명이 있을 수 있는 좌표의 수를 구하라.

## 구현 방법

두 명 (조규현, 백승환)의 좌표가 원의 중심이고, 반지름은 각각 r1와 r2인 두 원의 상관 관계를 구하면 된다.

```
[두 원의 관계]
- 두 점에서 만나는 경우
- 한 점에서 만나는 경우 (내접, 외접)
- 만나지 않는 경우 (한 원이 다른 원 안에 있는 경우 / 두 원이 떨어져있는 경우)
```
이 때 두 원의 중심이 같은 경우, 반지름이 같다면 무수히 많은 교접을 가지게 된다.
```c++
if (x == 0 && y == 0) {
	if (R == 0) cout << "-1" << '\n'; //두 원이 겹치는 경우
	else  cout << "0" << '\n'; 
}
```


## 참고 사항
- 시간 복잡도 : O(1)