### PR TITLE
[3주차] : BOJ 1756 / 피자 굽기 / 골드 5

### DIFF
--- a/KES/BOJ_1756.cpp
+++ b/KES/BOJ_1756.cpp
@@ -1,0 +1,31 @@
+#include<iostream>
+#include<vector>
+using namespace std;
+int main() {
+	vector<int> v;
+	vector<int> v2;
+	int counter, d, n, k, answer;
+	cin >> d >> n;
+	for (int i = 0; i < d; i++) {
+		cin >> k;
+		if (i != 0) {
+			if (k > v[i - 1]) k = v[i - 1];
+		}
+		v.push_back(k);
+	}
+	for (int i = 0; i < n; i++) {
+		cin >> k;
+		v2.push_back(k);
+	}
+	counter = 0;
+	answer = 0;
+	for (int i = d - 1; i >=0; i--) {
+		if (v2[counter] <= v[i]) {
+			counter++;
+			answer = i;
+		}
+		if (counter == n) break;
+	}
+	if (answer <= 0) cout << 0;
+	else cout << answer + 1;
+}


### PR DESCRIPTION
## 문제 해결
[피자 굽기](https://www.acmicpc.net/problem/1756)
이 가게에서는 피자 반죽의 지름이 제각각이고, 오븐의 모양도 깊은 관 모양인데, 관의 지름이 들쭉날쭉 하다.


[오븐 단면의 예시]
![화면 캡처 2022-08-28 120316](https://user-images.githubusercontent.com/74243990/187055625-88b08b6e-2880-4888-9a30-2d2170f99232.jpg)

피자 반죽은 완성되는 순서대로 들어갈 때, 맨 위의 피자가 얼마나 깊이 들어가있는지 알아내는 프로그램을 작성하시오.

## 구현 방법

오븐 단면의 모양은 들쭉날쭉하지만, 들어갈 수 있는 피자의 크기는 상단의 관 크기에 따라서 결정된다.
즉, 예시와 같은 오븐 단면이 주어진다면, 실제로 들어갈 수 있는 피자의 크기는 다음 그림과 같다.
![화면 캡처 2022-08-28 120654](https://user-images.githubusercontent.com/74243990/187055719-8a322b13-9a94-4740-ba78-ac138bf4742f.jpg)
```
실제 피자 관의 크기            계산할 피자 관의 크기
        5                             5
        6                             5
        4                             4
        3                             3
        6                             3
        2                             2
        3                             2
```                             
이에 따라서 주어진 피자 관의 크기를 조절한다.
```c++
cin >> k;
if (i != 0) {
	if (k > v[i - 1]) k = v[i - 1];
}
v.push_back(k);

```
계산이 용이하게 피자 관의 크기를 조절해 준 후, 피자 관의 아래쪽부터 계산하여 최종 피자 도우의 위치를 구해준다. 

```c++
for (int i = d - 1; i >=0; i--) {
		if (v2[counter] <= v[i]) {
			counter++;
			answer = i;
		}
		if (counter == n) break;
	}
if (answer <= 0) cout << 0;
else cout << answer + 1;
```


## 참고 사항
- 시간 복잡도: O(N)