### PR TITLE
[5주차] : BOJ 11048 / 이동하기 / 실버 2

### DIFF
--- a/KHE/BOJ_11048.cpp
+++ b/KHE/BOJ_11048.cpp
@@ -1,0 +1,26 @@
+#include <iostream>
+#include <algorithm>
+using namespace std;
+
+int maze[1001][1001] = { 0, };
+int dp[1001][1001] = { 0, };
+
+int main() {
+	int n, m;
+	cin >> n >> m;
+
+	for (int i = 1; i <= n; i++) {
+		for (int j = 1; j <= m; j++) {
+			cin >> maze[i][j];
+		}
+	}
+	
+	for (int i = 1; i <= n; i++) {
+		for (int j = 1; j <= m; j++) {
+			dp[i][j] = max(max(dp[i - 1][j], dp[i][j - 1]), dp[i - 1][j - 1]) + maze[i][j];
+		}
+	}
+	
+	cout << dp[n][m];
+
+}


### PR DESCRIPTION
## 문제 설명
[이동하기](https://www.acmicpc.net/problem/11048)

NxM 미로에서 준규가 (1, 1)에서 (N,M)으로 이동하려고 한다. 
준규가 (r,c)에 있을 때 이동할 수 있는 경우의 수는 (r+1, c), (r, c+1), (r+1, c+1)의 세 가지가 있다.
이동 시 각 방에 놓여져있는 사탕을 함께 가져 갈 때, (N,M)에 도착했을 때 가져올 수 있는 사탕의 최댓값을 구한다. 


## 구현 방법

현재 좌표까지 얻을 수 있는 사탕의 갯수는 이전 좌표까지 모은 사탕의 개수 중 최댓값 + 현재 위치의 사탕 개수이다.
그리고 현재 위치를 (i,j)라고 하면, 이전 좌표는 (i-1, j), (i, j-1), (i-1, j-1) 세 가지가 있으므로 식을 세우면 아래와 같다.
```c
for (int i = 1; i <= n; i++) {
	for (int j = 1; j <= m; j++) {
		dp[i][j] = max(max(dp[i - 1][j], dp[i][j - 1]), dp[i - 1][j - 1]) + maze[i][j];
	}
}
```


## 참고 사항
- 시간 복잡도 : `O(N^2)`