### PR TITLE
[6주차] : BOJ 1208 / 부분수열의 합 2 / 골드 1

### DIFF
--- a/KSH/BOJ_1208.cpp
+++ b/KSH/BOJ_1208.cpp
@@ -1,0 +1,65 @@
+//
+// Created by Kim So Hee on 2022/09/22.
+//
+
+#include <bits/stdc++.h>
+
+using namespace std;
+
+int n, s;
+long long answer;
+vector<int> inputs;
+vector<int> sums[2];
+
+void gen(int end, int index, int sum) {
+    if (index == end) return;
+
+    int next = sum + inputs[index];
+    if (next == s) answer++;
+
+    if (end == n) sums[1].push_back(next);
+    else sums[0].push_back(next);
+
+    gen(end, index + 1, next);
+    gen(end, index + 1, sum);
+}
+
+int main() {
+    ios::sync_with_stdio(false);
+    cin.tie(nullptr);
+    cout.tie(nullptr);
+
+    cin >> n >> s;
+
+    inputs.resize(n);
+
+    for (int i = 0; i < n; ++i) cin >> inputs[i];
+
+    /**
+     * N의 범위의 절반 값으로 문제를 해결 할 수 있을 때, Meet in the middle 기법을 고려해볼 수 있다.
+     *  - 한 개의 그룹으로 완전 탐색을 하지 못하는 경우 두 개의 그룹으로 나누어 탐색
+     *
+     * mid 값을 기준으로 [0~mid), [mid, N) 로 두 개의 문제로 쪼개보자.
+     * 우리가 찾고자 하는 합이 S가 되는 부분수열은 3가지 case 에 속한다.
+        1. 부분 수열이 [0~mid) 에만 속한다.
+        2. 부분 수열이 [mid~N) 에만 속한다.
+        3. 부분 수열이 left, right에 걸쳐 존재한다.
+     */
+    gen(n / 2, 0, 0);
+    gen(n, n / 2, 0);
+
+    std::sort(sums[1].begin(), sums[1].end());
+
+    /**
+     * 개선 사항
+     *  - gen 함수에서 집합의 합을 map으로 저장해서(sum:count) 체크할 수 있음
+     *  - 굳이 이분 탐색 추가로 안해도 됨
+     */
+    for (const auto &sum: sums[0]) {
+        auto lower = std::lower_bound(sums[1].begin(), sums[1].end(), s - sum) - sums[1].begin();
+        auto upper = std::upper_bound(sums[1].begin(), sums[1].end(), s - sum) - sums[1].begin();
+        answer += upper - lower;
+    }
+
+    cout << answer;
+}


### PR DESCRIPTION
## 문제 설명
[부분수열의 합 2](https://www.acmicpc.net/problem/1208)

N개의 정수로 이루어진 수열이 있을 때, 크기가 양수인 부분수열 중에서 
그 수열의 원소를 다 더한 값이 S가 되는 경우의 수를 구하는 프로그램을 작성하시오.
- 정수 N 최대 40
- 합 S 최대 100만
- 수열 원소 절댓값 범위 최대 10만

## 구현 방법
[부분수열의 합 1](https://www.acmicpc.net/problem/1182)보다 N의 범위가 20에서 40으로 변경되었다. 
N이 20일 때는 단순히 부분집합을 모두 생성(최대 2^20)하여 구할 수 있었다. 
그러나 N이 40이면 2^40, 시간초과가 난다. 

하지만 이 문제는 두 수열로(최대 길이 20)으로 쪼개서 답을 구할 수 있다
1. 수열을 반으로 쪼개서, 각각 모든 부분집합의 합을 완전 탐색으로 생성하여 배열에 저장한다. 
```c++
void gen(int end, int index, int sum) {
    if (index == end) return;

    int next = sum + inputs[index];
    if (next == s) answer++;

    if (end == n) sums[1].push_back(next);
    else sums[0].push_back(next);

    gen(end, index + 1, next);
    gen(end, index + 1, sum);
}

```

2. 합 S가 두 수열에 걸쳐 있는 경우를 위해, 2개의 합 배열을 활용하여 경우의 수를 추가 계산한다. 
```c++
  for (const auto &sum: sums[0]) {
        auto lower = std::lower_bound(sums[1].begin(), sums[1].end(), s - sum) - sums[1].begin();
        auto upper = std::upper_bound(sums[1].begin(), sums[1].end(), s - sum) - sums[1].begin();
        answer += upper - lower;
    }
```

## 참고 사항
- **meet in the middle**
   - N의 범위의 절반 값으로 문제를 해결 할 수 있을 때, Meet in the middle 기법을 고려해볼 수 있다. 
   - 한 개의 그룹으로 완전 탐색을 하지 못하는 경우 두 개의 그룹으로 나누어 탐색한다. 
- 시간 복잡도 : `O(2^n * n)`
